### PR TITLE
Change Prometheus image to SolDevelo version

### DIFF
--- a/deploy/yaml/prometheus.yaml
+++ b/deploy/yaml/prometheus.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: linkme-prometheus
-          image: bitnami/prometheus:latest
+          image: soldevelo/prometheus:latest
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsGroup: 0


### PR DESCRIPTION
This change updates the Prometheus container image from `bitnami/prometheus:latest` to `soldevelo/prometheus:latest` to ensure the monitoring component remains reliable and consistently available across all environments.

The Bitnami Prometheus image can introduce availability and distribution constraints that may impact local development setups and CI/CD pipelines. Replacing it with the SolDevelo-maintained image ensures a stable, drop-in compatible alternative without changing any runtime configuration or Prometheus behavior.

This update improves the robustness of the deployment by:

* removing dependency on externally constrained images
* ensuring consistent availability in CI and local environments
* keeping full compatibility with existing Prometheus configuration
* aligning with the project’s broader move toward SolDevelo-maintained infrastructure images

No functional changes were introduced - this is a direct image replacement only.